### PR TITLE
Fix relative import in __init__.py

### DIFF
--- a/fsb5/__init__.py
+++ b/fsb5/__init__.py
@@ -208,8 +208,8 @@ class FSB5:
 			return sample.data
 		elif self.header.mode == SoundFormat.VORBIS:
 			# import here as vorbis.py requires native libraries
-			from . import vorbis
-			return vorbis.rebuild(sample)
+			from .vorbis import rebuild
+			return rebuild(sample)
 		elif self.header.mode.is_pcm:
 			from .pcm import rebuild
 			if self.header.mode == SoundFormat.PCM8:


### PR DESCRIPTION
I don't remember when, but python3 changed relative import behaviour - I was getting an `ImportError` on the `from . import vorbis` line.