### PR TITLE
Fix Stereo PCM Extraction

### DIFF
--- a/fsb5/pcm.py
+++ b/fsb5/pcm.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 
 def rebuild(sample, width):
-	data = sample.data[:sample.samples * width]
+	data = sample.data[:sample.samples * sample.channels * width]
 	ret = BytesIO()
 	with wave.open(ret, "wb") as wav:
 		wav.setparams((sample.channels, width, sample.frequency, 0, "NONE", "NONE"))


### PR DESCRIPTION
Extracting Stereo PCM allocation need to use `sample.channels`.
Otherwise, only Mono PCM works, or only the first half of the Stero PCM got written.